### PR TITLE
move `firecracker-report-parser` code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pom.xml.asc
 config.json
 /.cpcache
 /.lsp/sqlite.db
+/.lsp/.cache
+/.clj-kondo/.cache
+

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/ClojureProjectResolveSettings.xml
+++ b/.idea/ClojureProjectResolveSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ClojureProjectResolveSettings">
+    <currentScheme>IDE</currentScheme>
+  </component>
+</project>

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/clojure-deps.xml
+++ b/.idea/clojure-deps.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DepsProjectSettings">
+    <option name="enabledAliases">
+      <set>
+        <option value="dev" />
+        <option value="test" />
+      </set>
+    </option>
+  </component>
+  <component name="DepsProjectsManager">
+    <option name="projectFiles">
+      <list>
+        <option value="file://$PROJECT_DIR$/deps.edn" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="practitest-firecracker" target="1.5" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/.idea/libraries/Deps__ch_qos_logback_logback_classic_1_2_3.xml
+++ b/.idea/libraries/Deps__ch_qos_logback_logback_classic_1_2_3.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: ch.qos.logback/logback-classic:1.2.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__ch_qos_logback_logback_core_1_2_3.xml
+++ b/.idea/libraries/Deps__ch_qos_logback_logback_core_1_2_3.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: ch.qos.logback/logback-core:1.2.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.2.3/logback-core-1.2.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__cheshire_5_10_0.xml
+++ b/.idea/libraries/Deps__cheshire_5_10_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: cheshire:5.10.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/cheshire/cheshire/5.10.0/cheshire-5.10.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__clj_http_3_12_0.xml
+++ b/.idea/libraries/Deps__clj_http_3_12_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: clj-http:3.12.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/clj-http/clj-http/3.12.0/clj-http-3.12.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__clj_time_0_15_2.xml
+++ b/.idea/libraries/Deps__clj_time_0_15_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: clj-time:0.15.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/clj-time/clj-time/0.15.2/clj-time-0.15.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__clj_tuple_0_2_2.xml
+++ b/.idea/libraries/Deps__clj_tuple_0_2_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: clj-tuple:0.2.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/clj-tuple/clj-tuple/0.2.2/clj-tuple-0.2.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__com_fasterxml_jackson_core_jackson_core_2_10_2.xml
+++ b/.idea/libraries/Deps__com_fasterxml_jackson_core_jackson_core_2_10_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: com.fasterxml.jackson.core/jackson-core:2.10.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.10.2/jackson-core-2.10.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_10_2.xml
+++ b/.idea/libraries/Deps__com_fasterxml_jackson_dataformat_jackson_dataformat_cbor_2_10_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: com.fasterxml.jackson.dataformat/jackson-dataformat-cbor:2.10.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.10.2/jackson-dataformat-cbor-2.10.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__com_fasterxml_jackson_dataformat_jackson_dataformat_smile_2_10_2.xml
+++ b/.idea/libraries/Deps__com_fasterxml_jackson_dataformat_jackson_dataformat_smile_2_10_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: com.fasterxml.jackson.dataformat/jackson-dataformat-smile:2.10.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/dataformat/jackson-dataformat-smile/2.10.2/jackson-dataformat-smile-2.10.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__commons_codec_1_12.xml
+++ b/.idea/libraries/Deps__commons_codec_1_12.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: commons-codec:1.12">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.12/commons-codec-1.12.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__commons_io_2_6.xml
+++ b/.idea/libraries/Deps__commons_io_2_6.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: commons-io:2.6">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-io/commons-io/2.6/commons-io-2.6.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__commons_logging_1_2.xml
+++ b/.idea/libraries/Deps__commons_logging_1_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: commons-logging:1.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.2/commons-logging-1.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__github_PractiTest_firecracker_report_parser_9fed1a.xml
+++ b/.idea/libraries/Deps__github_PractiTest_firecracker_report_parser_9fed1a.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: github-PractiTest/firecracker-report-parser:9fed1a">
+    <CLASSES>
+      <root url="file://$USER_HOME$/.gitlibs/libs/github-PractiTest/firecracker-report-parser/9fed1ab43b42f1b6d426925eaf159e620e793c56/src/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__github_PractiTest_firecracker_report_parser_9fed1a.xml
+++ b/.idea/libraries/Deps__github_PractiTest_firecracker_report_parser_9fed1a.xml
@@ -1,9 +1,0 @@
-<component name="libraryTable">
-  <library name="Deps: github-PractiTest/firecracker-report-parser:9fed1a">
-    <CLASSES>
-      <root url="file://$USER_HOME$/.gitlibs/libs/github-PractiTest/firecracker-report-parser/9fed1ab43b42f1b6d426925eaf159e620e793c56/src/" />
-    </CLASSES>
-    <JAVADOC />
-    <SOURCES />
-  </library>
-</component>

--- a/.idea/libraries/Deps__joda_time_2_10.xml
+++ b/.idea/libraries/Deps__joda_time_2_10.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: joda-time:2.10">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.10/joda-time-2.10.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpasyncclient_4_1_4.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpasyncclient_4_1_4.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpasyncclient:4.1.4">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpasyncclient/4.1.4/httpasyncclient-4.1.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpclient_4_5_13.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpclient_4_5_13.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpclient:4.5.13">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpclient_cache_4_5_13.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpclient_cache_4_5_13.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpclient-cache:4.5.13">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient-cache/4.5.13/httpclient-cache-4.5.13.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpcore_4_4_13.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpcore_4_4_13.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpcore:4.4.13">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpcore_nio_4_4_10.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpcore_nio_4_4_10.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpcore-nio:4.4.10">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore-nio/4.4.10/httpcore-nio-4.4.10.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_apache_httpcomponents_httpmime_4_5_13.xml
+++ b/.idea/libraries/Deps__org_apache_httpcomponents_httpmime_4_5_13.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.apache.httpcomponents/httpmime:4.5.13">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpmime/4.5.13/httpmime-4.5.13.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_clojure_1_10_3.xml
+++ b/.idea/libraries/Deps__org_clojure_clojure_1_10_3.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/clojure:1.10.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/clojure/1.10.3/clojure-1.10.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_core_async_1_2_603.xml
+++ b/.idea/libraries/Deps__org_clojure_core_async_1_2_603.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/core.async:1.2.603">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/core.async/1.2.603/core.async-1.2.603.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_core_cache_0_8_2.xml
+++ b/.idea/libraries/Deps__org_clojure_core_cache_0_8_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/core.cache:0.8.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/core.cache/0.8.2/core.cache-0.8.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_core_memoize_0_8_2.xml
+++ b/.idea/libraries/Deps__org_clojure_core_memoize_0_8_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/core.memoize:0.8.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/core.memoize/0.8.2/core.memoize-0.8.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_core_specs_alpha_0_2_56.xml
+++ b/.idea/libraries/Deps__org_clojure_core_specs_alpha_0_2_56.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/core.specs.alpha:0.2.56">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/core.specs.alpha/0.2.56/core.specs.alpha-0.2.56.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_data_priority_map_0_0_7.xml
+++ b/.idea/libraries/Deps__org_clojure_data_priority_map_0_0_7.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/data.priority-map:0.0.7">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/data.priority-map/0.0.7/data.priority-map-0.0.7.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_spec_alpha_0_2_194.xml
+++ b/.idea/libraries/Deps__org_clojure_spec_alpha_0_2_194.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/spec.alpha:0.2.194">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/spec.alpha/0.2.194/spec.alpha-0.2.194.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_tools_analyzer_1_0_0.xml
+++ b/.idea/libraries/Deps__org_clojure_tools_analyzer_1_0_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/tools.analyzer:1.0.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/tools.analyzer/1.0.0/tools.analyzer-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_tools_analyzer_jvm_1_0_0.xml
+++ b/.idea/libraries/Deps__org_clojure_tools_analyzer_jvm_1_0_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/tools.analyzer.jvm:1.0.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/tools.analyzer.jvm/1.0.0/tools.analyzer.jvm-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_tools_cli_1_0_194.xml
+++ b/.idea/libraries/Deps__org_clojure_tools_cli_1_0_194.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/tools.cli:1.0.194">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/tools.cli/1.0.194/tools.cli-1.0.194.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_tools_logging_1_1_0.xml
+++ b/.idea/libraries/Deps__org_clojure_tools_logging_1_1_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/tools.logging:1.1.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/tools.logging/1.1.0/tools.logging-1.1.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_clojure_tools_reader_1_3_2.xml
+++ b/.idea/libraries/Deps__org_clojure_tools_reader_1_3_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.clojure/tools.reader:1.3.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/clojure/tools.reader/1.3.2/tools.reader-1.3.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_ow2_asm_asm_5_2.xml
+++ b/.idea/libraries/Deps__org_ow2_asm_asm_5_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.ow2.asm/asm:5.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/ow2/asm/asm/5.2/asm-5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__org_slf4j_slf4j_api_1_7_25.xml
+++ b/.idea/libraries/Deps__org_slf4j_slf4j_api_1_7_25.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: org.slf4j/slf4j-api:1.7.25">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__potemkin_0_4_5.xml
+++ b/.idea/libraries/Deps__potemkin_0_4_5.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: potemkin:0.4.5">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/potemkin/potemkin/0.4.5/potemkin-0.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__riddley_0_1_12.xml
+++ b/.idea/libraries/Deps__riddley_0_1_12.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: riddley:0.1.12">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/riddley/riddley/0.1.12/riddley-0.1.12.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__slingshot_0_12_2.xml
+++ b/.idea/libraries/Deps__slingshot_0_12_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: slingshot:0.12.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/slingshot/slingshot/0.12.2/slingshot-0.12.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__throttler_1_0_0.xml
+++ b/.idea/libraries/Deps__throttler_1_0_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: throttler:1.0.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/throttler/throttler/1.0.0/throttler-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/Deps__tigris_0_1_2.xml
+++ b/.idea/libraries/Deps__tigris_0_1_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Deps: tigris:0.1.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/tigris/tigris/0.1.2/tigris-0.1.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <enabledExtensions>
+      <entry key="MermaidLanguageExtension" value="false" />
+      <entry key="PlantUMLLanguageExtension" value="false" />
+    </enabledExtensions>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/practitest-firecracker.iml" filepath="$PROJECT_DIR$/practitest-firecracker.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ If the structure of the report changes (new tests are added for example), you wi
 
 If you don't have an existing CONFIG_FILE and you want to use it, go to https://firecracker-ui-prod.practitest.com/ and generate one.
 To login, you can use your PractiTest credentials and follow the instructions in the link. Then you can continue here and set the config-path to your configuration file path.
+
+## Building uberjar
+
+```shell
+clojure -A:depstar -m hf.depstar.uberjar practitest-firecracker-standalone.jar -C -m practitest-firecracker.core
+```
+
 ## Usage
 
 ### help

--- a/deps.edn
+++ b/deps.edn
@@ -7,10 +7,7 @@
          throttler/throttler                         {:mvn/version "1.0.0"}
          org.clojure/tools.logging                   {:mvn/version "1.1.0"}
          ch.qos.logback/logback-classic              {:mvn/version "1.2.3"}
-         clj-time/clj-time                           {:mvn/version "0.15.2"}
-         github-PractiTest/firecracker-report-parser {:git/url       "git@github.com:PractiTest/firecracker-report-parser.git"
-                                                      :deps/manifest :deps
-                                                      :sha           "9fed1ab43b42f1b6d426925eaf159e620e793c56"}}
+         clj-time/clj-time                           {:mvn/version "0.15.2"}}
  :aliases
  {:dev       {:extra-paths ["dev"]}
   :package   {:extra-paths ["resources" "target/cljs/"]}

--- a/practitest-firecracker.iml
+++ b/practitest-firecracker.iml
@@ -29,7 +29,6 @@
     <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.0.194" level="project" />
     <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpasyncclient:4.1.4" level="project" />
     <orderEntry type="library" name="Deps: org.clojure/tools.analyzer.jvm:1.0.0" level="project" />
-    <orderEntry type="library" name="Deps: github-PractiTest/firecracker-report-parser:9fed1a" level="project" />
     <orderEntry type="library" name="Deps: com.fasterxml.jackson.dataformat/jackson-dataformat-cbor:2.10.2" level="project" />
     <orderEntry type="library" name="Deps: ch.qos.logback/logback-core:1.2.3" level="project" />
     <orderEntry type="library" name="Deps: slingshot:0.12.2" level="project" />

--- a/practitest-firecracker.iml
+++ b/practitest-firecracker.iml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module cursive.leiningen.project.DepsProjectsManager.isLeinModule="true" cursive.leiningen.project.LeiningenProjectsManager.displayName="practitest-firecracker" type="JAVA_MODULE" version="4">
+  <component name="BuildSystem">
+    <option name="buildSystemId" value="CLOJURE_DEPS" />
+    <option name="displayName" value="practitest-firecracker" />
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/dev" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.cpcache" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+      <excludeFolder url="file://$MODULE_DIR$/test-data" />
+      <excludeFolder url="file://$MODULE_DIR$/.clj-kondo/.cache" />
+      <excludeFolder url="file://$MODULE_DIR$/.lsp/.cache" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Deps: org.clojure/clojure:1.10.3" level="project" />
+    <orderEntry type="library" name="Deps: joda-time:2.10" level="project" />
+    <orderEntry type="library" name="Deps: commons-codec:1.12" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer:1.0.0" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.logging:1.1.0" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.specs.alpha:0.2.56" level="project" />
+    <orderEntry type="library" name="Deps: throttler:1.0.0" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/spec.alpha:0.2.194" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.cli:1.0.194" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpasyncclient:4.1.4" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.analyzer.jvm:1.0.0" level="project" />
+    <orderEntry type="library" name="Deps: github-PractiTest/firecracker-report-parser:9fed1a" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.dataformat/jackson-dataformat-cbor:2.10.2" level="project" />
+    <orderEntry type="library" name="Deps: ch.qos.logback/logback-core:1.2.3" level="project" />
+    <orderEntry type="library" name="Deps: slingshot:0.12.2" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore-nio:4.4.10" level="project" />
+    <orderEntry type="library" name="Deps: commons-io:2.6" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.core/jackson-core:2.10.2" level="project" />
+    <orderEntry type="library" name="Deps: clj-time:0.15.2" level="project" />
+    <orderEntry type="library" name="Deps: clj-http:3.12.0" level="project" />
+    <orderEntry type="library" name="Deps: org.ow2.asm/asm:5.2" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpcore:4.4.13" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient-cache:4.5.13" level="project" />
+    <orderEntry type="library" name="Deps: clj-tuple:0.2.2" level="project" />
+    <orderEntry type="library" name="Deps: riddley:0.1.12" level="project" />
+    <orderEntry type="library" name="Deps: commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpclient:4.5.13" level="project" />
+    <orderEntry type="library" name="Deps: cheshire:5.10.0" level="project" />
+    <orderEntry type="library" name="Deps: tigris:0.1.2" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/tools.reader:1.3.2" level="project" />
+    <orderEntry type="library" name="Deps: potemkin:0.4.5" level="project" />
+    <orderEntry type="library" name="Deps: org.slf4j/slf4j-api:1.7.25" level="project" />
+    <orderEntry type="library" name="Deps: ch.qos.logback/logback-classic:1.2.3" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.memoize:0.8.2" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/data.priority-map:0.0.7" level="project" />
+    <orderEntry type="library" name="Deps: org.apache.httpcomponents/httpmime:4.5.13" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.cache:0.8.2" level="project" />
+    <orderEntry type="library" name="Deps: org.clojure/core.async:1.2.603" level="project" />
+    <orderEntry type="library" name="Deps: com.fasterxml.jackson.dataformat/jackson-dataformat-smile:2.10.2" level="project" />
+  </component>
+</module>

--- a/src/practitest_firecracker/core.clj
+++ b/src/practitest_firecracker/core.clj
@@ -1,19 +1,18 @@
 (ns practitest-firecracker.core
   (:require
-   [practitest-firecracker.cli        :refer [parse-args]]
-   [practitest-firecracker.practitest :refer [make-client
-                                              create-sf-testset
-                                              make-runs
-                                              populate-sf-results
-                                              create-testsets
-                                              group-tests
-                                              create-or-update-tests
-                                              create-instances
-                                              create-runs]]
-   [firecracker-report-parser.core    :refer [send-directory parse-files]]
-   [clojure.pprint                    :as     pprint]
-   [clojure.java.io                   :refer [file]]
-   [clj-time.core                     :as     t])
+   [practitest-firecracker.cli         :refer [parse-args]]
+   [practitest-firecracker.practitest  :refer [make-client
+                                               make-runs
+                                               populate-sf-results
+                                               create-testsets
+                                               group-tests
+                                               create-or-update-tests
+                                               create-instances
+                                               create-runs]]
+   [practitest-firecracker.parser.core :refer [send-directory parse-files]]
+   [clojure.pprint                     :as     pprint]
+   [clojure.java.io                    :refer [file]]
+   [clj-time.core                      :as     t])
   (:gen-class))
 
 (defn exit [status msg]

--- a/src/practitest_firecracker/parser/core.clj
+++ b/src/practitest_firecracker/parser/core.clj
@@ -1,0 +1,200 @@
+(ns practitest-firecracker.parser.core
+  (:require
+    [clojure.java.io :as io]
+    [clojure.string :as str]
+    [clojure.xml :as xml]
+    [clojure.zip :as zip])
+  (:import (java.text NumberFormat)
+           (java.io ByteArrayInputStream)))
+
+(defn round
+  [x & {p :precision}]
+  (if (< x 0.006)
+    (if p
+      (let [scale (Math/pow 10 p)]
+        (-> x (* scale) Math/round (/ scale)))
+      (Math/round x))
+    x))
+
+(defn str-to-number [val]
+  (if (not (nil? val)) (.parse (NumberFormat/getInstance) val) 0))
+
+(defn zip-str [s]
+  (zip/xml-zip
+    (xml/parse (ByteArrayInputStream. (.getBytes s "UTF-8")))))
+
+(defn filter-tags [tag-key xml-content]
+  (let [filter-result (filter #(= (:tag %) tag-key) xml-content)]
+    filter-result))
+
+(defn get-attrs [obj]
+  (conj obj (:attrs obj)))
+
+(defn case-data [case]
+  (let [content        (:content case)
+        case-type      (filter #(contains? #{:error :failure :flake :skipped} (:tag %)) content)
+        system-message (filter #(contains? #{:system-out :system-err} (:tag %)) content)
+        attrs          (:attrs case)
+        name           (if (:classname attrs) (:name attrs) (last (str/split (:name attrs) #">")))]
+    (assoc attrs
+      :time (str-to-number (:time attrs))
+      :full-class-name (:classname attrs)
+      :full-name (str (:classname attrs) "." (:name attrs))
+      :has-failure? (some? case-type)
+      :failure-message (if case-type (get-in (first case-type) [:attrs :message]) nil)
+      :failure-detail (if system-message (str (first (:content (first system-message))) (first (:content (first case-type)))) nil)
+      :class-name (when (:classname attrs) (last (str/split (:classname attrs) #"\.")))
+      :failure-type (if (and case-type (first case-type)) (:tag (first case-type)) nil)
+      ;; :case-type         case-type
+      ;; :case-content      content
+      ;; :name              name
+      :test-case-name name
+      :pt-test-step-name name
+      :system-message system-message)))
+
+(defn get-case-info [test-cases]
+  (map case-data test-cases))
+
+(defn group-by-classname [val]
+  (last (str/split (:classname (:attrs val)) #"\.")))
+
+(defn group-by-name [val]
+  (last (str/split (:name (:attrs val)) #">")))
+
+(defn group-testcase-data [data multi-test-cases]
+  (let [grouping-func (if (contains? (:attrs (first data)) :classname)
+                        group-by-classname
+                        group-by-name)]
+    (if multi-test-cases
+      (->> data
+           (group-by grouping-func)
+           (map (fn [[k vals]] [k (into {:test-cases (get-case-info vals)} (first (map :attrs vals)))]))
+           (into {}))
+      (->> data
+           (map-indexed (fn [index val] {index (into {:test-cases (list (case-data val))} (:attrs val))}))
+           (into {})))))
+
+(defn test-data [test]
+  (let [package (if (:classname test) (clojure.string/join "." (drop-last (str/split (:classname test) #"\."))) (:name test))
+        name    (if (:classname test) (last (str/split (:classname test) #"\.")) (last (str/split (:name test) #">")))]
+    (assoc test
+      :errors (count (filter #(= (:failure-type %) :error) (:test-cases test)))
+      :failures (count (filter #(= (:failure-type %) :failure) (:test-cases test)))
+      :flakes (count (filter #(= (:failure-type %) :flake) (:test-cases test)))
+      :skipped (count (filter #(= (:failure-type %) :skipped) (:test-cases test)))
+      :tests (count (:test-cases test))
+      ;; :name                  name
+      ;; :name-test-suite       name
+      :suite-name (:suite-name test)
+      :pt-first-case-name (:name (first (:test-cases test)))
+      :pt-test-name name
+      :pt-name-combine (str name " - " (:name (first (:test-cases test))))
+      :time-elapsed (round (reduce + (map :time (:test-cases test))) :precision 3)
+      :full-class-name (:classname test)
+      :package-name package)))
+
+(defn get-test-aggregations [test val]
+  (let [map-vals      (vals val)
+        map-vals-with (map #(assoc % :suite-name (:name (:attrs test))) map-vals)
+        result        (first (conj (or (:test-list test) []) (map test-data map-vals-with)))]
+    result))
+
+(defn get-another-lvl-data [multi-test-cases sample data]
+  (let [content-data (if sample (keep-indexed #(if (> 20 %1) %2) (:content data)) (:content data))]
+    (case (:tag data)
+      :testsuite (assoc (get-attrs data) :test-list
+                                         (get-test-aggregations data (group-testcase-data (filter-tags :testcase content-data) multi-test-cases)))
+      :testsuites (assoc data :testsuite-list
+                              (for [suite content-data]
+                                (get-another-lvl-data multi-test-cases sample suite)))
+      nil)))
+
+(defn clean-content [testsuite]
+  (let [val (map (fn [suite]
+                   (assoc suite :content nil)) (:testsuite-list testsuite))]
+    {:testsuite-list (filter-tags :testsuite val)}))
+
+(defn get-data [parsed-file multi-test-cases sample]
+  (let [first-parsed-file (first parsed-file)]
+    (if (= (:tag first-parsed-file) :testsuites)
+      (->> first-parsed-file
+           (get-another-lvl-data multi-test-cases sample)
+           clean-content
+           (into {}))
+      (->> {:tag :testsuites :content parsed-file}
+           (get-another-lvl-data multi-test-cases sample)
+           clean-content
+           (into {})))))
+
+(defn testset-vals [gf]
+  (let [val    (:testsuite-list gf)
+        result (reduce conj () val)]
+    result))
+
+(defn get-files-data [parsed-files multi-test-cases sample]
+  (let [grouped-files  (for [file parsed-files] (get-data file multi-test-cases sample))
+        grouped        grouped-files
+        testsuite-list (flatten (map testset-vals grouped))
+        ]
+    testsuite-list))
+
+(defn merged-testset [testsets tests testset-name]
+  (list {:tag       :testsuite
+         :test-list tests
+         :name      testset-name
+         :tests     (reduce + (map #(str-to-number %) (map :tests testsets)))
+         :time      (reduce + (map #(str-to-number %) (map :time testsets)))
+         :failures  (reduce + (map #(str-to-number %) (map :failues testsets)))
+         :skipped   (reduce + (map #(str-to-number %) (map :skipped testsets)))
+         }))
+
+(defn merge-testsets [testsets testset-name]
+  (let [group-tests (flatten (reduce conj (for [testset testsets] (:test-list testset))))]
+    (merged-testset testsets group-tests testset-name)))
+
+(defn merge-testsets-by-name [testsets]
+  (let [testsets-by-name (group-by :name testsets)
+        merged-testsets  (for [sub-testsets testsets-by-name]
+                           (reduce conj (merge-testsets (last sub-testsets) (first sub-testsets))))]
+    merged-testsets))
+
+(defn parse-n-merge-data [grouped-files-map parsed-content]
+  (let [merge-content (merge (get grouped-files-map (:test-list parsed-content)) parsed-content)]
+    merge-content))
+
+(defn get-files-path [directory]
+  (let [file-seqs      (.listFiles (io/file directory))
+        filtered-files (filter (fn [file] (str/ends-with? (.getAbsolutePath file) ".xml")) file-seqs)
+        filtered-paths (for [file filtered-files] (.getAbsolutePath file))]
+    filtered-paths))
+
+(defn parse-files [directory]
+  (let [filtered-paths (get-files-path directory)
+        files          (for [path filtered-paths] (slurp path))
+        parsed-files   (for [file files] (zip-str file))]
+    parsed-files))
+
+(defn merge-results [parsed-files multi-test-cases multi-testsets testset-name sample]
+  (let [grouped-data (get-files-data parsed-files multi-test-cases sample)
+        result       (if multi-testsets (merge-testsets-by-name grouped-data) (merge-testsets grouped-data testset-name))
+        ]
+    result))
+
+(defn send-directory [parsed-dirs multi-test-cases multi-testsets testset-name sample]
+  (let [result (first
+                 (conj (list)
+                       (first
+                         (for [dir parsed-dirs]
+                           (merge-results dir multi-test-cases multi-testsets testset-name sample)))))]
+    result))
+
+(defn get-dir-by-path [path multi-test-cases multi-testsets testset-name sample]
+  (let [directory   (clojure.java.io/file path)
+        parsed-dirs (for [dir (file-seq directory)] (parse-files dir))]
+    (send-directory parsed-dirs multi-test-cases multi-testsets testset-name sample)))
+
+(defn -main [& [arg multi-test-cases multi-testsets testset-name sample]]
+  (if-not (empty? arg)
+    (let [result (get-dir-by-path arg (= "true" multi-test-cases) (= "true" multi-testsets) testset-name (= "true" sample))]
+      result)
+    (throw (Exception. "Must have at least one argument!"))))

--- a/src/practitest_firecracker/parser/utils.clj
+++ b/src/practitest_firecracker/parser/utils.clj
@@ -1,0 +1,13 @@
+(ns practitest-firecracker.parser.utils
+  (:require
+   [clojure.pprint  :as pprint]
+   [clojure.string  :as str]))
+
+(defn return-file [file]
+  (pprint/pprint (slurp file)))
+
+(defn return-files [directory]
+  (let [filtered-files   (filter (fn [file] (str/ends-with? (.getAbsolutePath file) ".xml")) (file-seq directory))
+        filtered-paths   (for [file filtered-files] (.getAbsolutePath file))
+        files            (for [path filtered-paths] (return-file path))]
+    files))


### PR DESCRIPTION
Will simplify working with the repository and we still can reuse it from UI backend by importing the parser from this repo.