### PR TITLE
Fixed issues in BDD support

### DIFF
--- a/src/practitest_firecracker/parser/gherkin.clj
+++ b/src/practitest_firecracker/parser/gherkin.clj
@@ -36,7 +36,7 @@
 (defn- expand-scenario-outline
   [scenario feature]
   (let [examples (:examples scenario)
-        all-params (glue-example-arguments (first examples))]
+        all-params (mapcat glue-example-arguments examples)]
     (mapcat
       (fn [param]
         ;; Store params and values here for future reference

--- a/src/practitest_firecracker/parser/gherkin.clj
+++ b/src/practitest_firecracker/parser/gherkin.clj
@@ -58,6 +58,9 @@
              (:map param)] result]]))
          all-params)))
 
+(defn- examples-section-end? [line]
+  (str/starts-with? (str/lower-case (str/trim line)) "scenario:"))
+
 ;; TODO: tags support ??
 (defn- extract-scenario-source
   [feature-root scenario]
@@ -73,13 +76,13 @@
 
                    outline?
                    ;; For outline need to extract examples as well
-                   (let [start-examples (:line (:location (last (:examples scenario))))]
-                     ;; Find end of examples sections - either end of file or empty line
+                   (let [start-examples (:line (:location (first (:examples scenario))))]
+                     ;; Find end of examples sections - either end of file or new BDD scenario
                      (loop [i start-examples
                             coll (seq (drop start-examples feature-source))]
                        (if coll
                          (let [line (first coll)]
-                           (if (str/blank? line)
+                           (if (examples-section-end? line)
                              i
                              (recur (inc i) (next coll))))
                          i)))

--- a/src/practitest_firecracker/practitest.clj
+++ b/src/practitest_firecracker/practitest.clj
@@ -319,13 +319,16 @@
   (when display-action-logs (log/infof "make-runs"))
   (flatten (doall
              (for [[test-testset instances] instance-to-ts-test]
-               (map-indexed
-                 (fn [index instance]
+               (map
+                 (fn [instance]
                    (let [[_ test-id] test-testset
                          tst (first (get test-by-id test-id))
                          test-name (get tst 0)
-                         params (get test-name-to-params test-name)
-                         this-param  (get params index)
+                         this-param (:parameters (:attributes instance))
+                         ;; Use nil in case of empty params
+                         this-param (if (empty? this-param)
+                                      nil
+                                      this-param)
                          xml-test (get group-xml-tests [test-name this-param])
                          sys-test (get tst 1)
                          [run run-steps] (eval/sf-test-suite->run-def options (first xml-test) sys-test this-param)

--- a/test/gherkin/identity.feature
+++ b/test/gherkin/identity.feature
@@ -8,7 +8,16 @@ Feature: Identity feature
         Then I will get result <result> every time
 
     Examples:
+
             | arg           | result        |
             | "First Item"  | "First Item"  |
             | "Second Item" | "Second 123" |
             | "Third Item"  | "Third Item"  |
+
+    Examples:
+
+            | arg           | result        |
+            | "Second Part" | "Second Part" |
+            | "Failure"     | "That would fail" |
+
+    Scenario: Another schenario just in case

--- a/test/gherkin/identity.feature
+++ b/test/gherkin/identity.feature
@@ -3,20 +3,20 @@ Feature: Identity feature
         Given I run identity function with 1
         Then I will get result 1
 
-    Scenario Outline: Multiple identity tests for <arg> and <result> with "Some quoutes"
-        When I run identity function with <arg>
-        Then I will get result <result> every time
+    Scenario Outline: Multiple identity tests for <First Arg> and <Second Arg> with "Some quoutes"
+        When I run identity function with <First Arg>
+        Then I will get result <Second Arg> every time
 
     Examples:
 
-            | arg           | result        |
+            | First Arg     | Second Arg    |
             | "First Item"  | "First Item"  |
-            | "Second Item" | "Second 123" |
+            | "Second Item" | "Second 123"  |
             | "Third Item"  | "Third Item"  |
 
     Examples:
 
-            | arg           | result        |
+            | First Arg     | Second Arg    |
             | "Second Part" | "Second Part" |
             | "Failure"     | "That would fail" |
 


### PR DESCRIPTION
* Support empty lines after `Examples:` keyword
* Support multiple `Examples:` sections for one scenario outline
* Fixed matching instances and steps on run creations

https://practitest-uri.atlassian.net/browse/PT1-3160
https://practitest-uri.atlassian.net/browse/PT1-3161
