### PR TITLE
pt1-4945_FC_run_fields_not_filled

### DIFF
--- a/src/practitest_firecracker/parser/core.clj
+++ b/src/practitest_firecracker/parser/core.clj
@@ -347,26 +347,28 @@
                (not specflow-scenario))
       (log/warn "Unable to detect BDD scenario for test" (:classname test) (:name test) " - will create FC test"))
 
-    (assoc test
-      :bdd-test? (some? bdd-scenario)
-      :gherkin-scenario bdd-scenario
-      ;; Extract scenario outline params to special arg (accessible via ?outline-params-row in firecracker config)
-      :outline-params-row (:row (:outline-params bdd-scenario))
-      :outline-params-map (:map (:outline-params bdd-scenario))
-      :errors (count (filter #(= (:failure-type %) :error) (:test-cases test)))
-      :failures (count (filter #(= (:failure-type %) :failure) (:test-cases test)))
-      :flakes (count (filter #(= (:failure-type %) :flake) (:test-cases test)))
-      :skipped (count (filter #(= (:failure-type %) :skipped) (:test-cases test)))
-      :tests (count (:test-cases test))
-      ;; :name                  name
-      ;; :name-test-suite       name
-      :suite-name (:suite-name test)
-      :pt-first-case-name (:name (first (:test-cases test)))
-      :pt-test-name name
-      :pt-name-combine (str name " - " (:name (first (:test-cases test))))
-      :time-elapsed (round (reduce + (map :time (:test-cases test))) :precision 3)
-      :full-class-name (:classname test)
-      :package-name package)))
+    (merge
+      ;; Computed defaults (lowest priority)
+      {:errors (count (filter #(= (:failure-type %) :error) (:test-cases test)))
+       :failures (count (filter #(= (:failure-type %) :failure) (:test-cases test)))
+       :flakes (count (filter #(= (:failure-type %) :flake) (:test-cases test)))
+       :skipped (count (filter #(= (:failure-type %) :skipped) (:test-cases test)))
+       :tests (count (:test-cases test))}
+      ;; Original XML attributes (higher priority - user settings override defaults)
+      test
+      ;; Required computed fields (highest priority - must be set)
+      {:bdd-test? (some? bdd-scenario)
+       :gherkin-scenario bdd-scenario
+       ;; Extract scenario outline params to special arg (accessible via ?outline-params-row in firecracker config)
+       :outline-params-row (:row (:outline-params bdd-scenario))
+       :outline-params-map (:map (:outline-params bdd-scenario))
+       :suite-name (:suite-name test)
+       :pt-first-case-name (:name (first (:test-cases test)))
+       :pt-test-name name
+       :pt-name-combine (str name " - " (:name (first (:test-cases test))))
+       :time-elapsed (round (reduce + (map :time (:test-cases test))) :precision 3)
+       :full-class-name (:classname test)
+       :package-name package})))
 
 (defn get-test-aggregations [test val {:keys [scenarios-map]
                                        :as options}]

--- a/src/practitest_firecracker/practitest.clj
+++ b/src/practitest_firecracker/practitest.clj
@@ -331,8 +331,8 @@
                                       this-param)
                          xml-test (get group-xml-tests [test-name this-param])
                          sys-test (get tst 1)
-                         [run run-steps] (eval/sf-test-suite->run-def options (first xml-test) sys-test this-param)
-                         additional-run-fields (eval/eval-additional-fields run (:additional-run-fields options))
+                         [_run-duration run-steps] (eval/sf-test-suite->run-def options (first xml-test) sys-test this-param)
+                         additional-run-fields (eval/eval-additional-fields (first xml-test) (:additional-run-fields options))
                          additional-run-fields (merge additional-run-fields (:system-fields additional-run-fields))
                          run (eval/sf-test-run->run-def additional-run-fields sys-test)]
                      {:instance-id (:id instance)


### PR DESCRIPTION
https://practitest-uri.atlassian.net/browse/PT1-4945

## Firecracker (practitest-firecracker)

  ### What has been changed?
  Fixed custom field mapping from XML attributes for both tests and runs. XML
  attribute values like `skipped="111"` were not being populated correctly.

  ### Why is this needed?
  Users configure custom field mappings in their JSON config (e.g.,
  `"---f-306": "?skipped"`), but:
  1. **Tests**: The `:skipped` XML attribute was being overwritten by a
  computed count (always 0 if no skipped test cases)
  2. **Runs**: The `eval-additional-fields` function received wrong data (`run`
   with only `:run-duration`) instead of the XML test data containing the
  actual attributes

  ### Implementation Details
  - `parser/core.clj`: Changed `test-data` from `assoc` to `merge` with
  priority order:
    1. Computed defaults (`:skipped`, `:errors`, etc.) - lowest priority
    2. Original XML attributes - user settings override defaults
    3. Required computed fields (`:bdd-test?`, `:pt-test-name`, etc.) - must be
   set

 - `practitest.clj`: Changed `make-runs` to pass `(first xml-test)` to
    `eval-additional-fields` instead of `run`, so XML attributes are accessible
    for field mapping

    **Before (broken):** Passed `run` which came from `sf-test-suite->run-def`
  output:
```clojure
    {:run-duration 3.218}
    When evaluating "?skipped", it looked for :skipped in this map and returned
   empty string (key not found).
```
    After (fixed): Passed (first xml-test) which contains the parsed XML 
```
  testcase data:
  {:name "Login Page error on wrong email format"
   :skipped "111"
   :classname "[chromium] › ..."
   :time "3.098"
   :projectname "chromium"
   :specfilename "01-old-cypress/admin/login.spec.js"
   ...}
    Now "?skipped" correctly resolves to "111" from the XML attribute.
  ```