### PR TITLE
PT1-7467 add option to set TestSet fields dynamically

### DIFF
--- a/src/practitest_firecracker/eval.clj
+++ b/src/practitest_firecracker/eval.clj
@@ -93,24 +93,23 @@
                     step-defs
                     (read-string (:id test)))))
 
-(defn update-sf-testset [client {:keys [project-id display-action-logs] :as options} testset-name sf-test-suite testset-id]
-  (let [[test-def step-defs] (sf-test-suite->test-def options sf-test-suite)
-        additional-testset-fields (:additional-testset-fields options)
+(defn update-sf-testset [client {:keys [project-id display-action-logs] :as options} testset-name representative-suite testset-id]
+  (let [additional-testset-fields (eval-additional-fields representative-suite (:additional-testset-fields options))
         additional-testset-fields (merge additional-testset-fields (:system-fields additional-testset-fields))]
     (ensure-custom-field-values client [project-id display-action-logs] (:custom-fields additional-testset-fields))
     (api/ll-update-testset client
                        [project-id display-action-logs]
-                       (merge test-def
-                              {:name testset-name}
+                       (merge {:name testset-name}
                               {:author-id (:author-id options)}
                               additional-testset-fields)
-                       step-defs
+                       []
                        testset-id)))
 
-(defn create-sf-testset [client options sf-test-suites testset-name]
+(defn create-sf-testset [client options sf-test-suites testset-name representative-suite]
   (let [tests (map (partial create-sf-test client options) sf-test-suites)
-        additional-testset-fields (:additional-testset-fields options)
+        additional-testset-fields (eval-additional-fields representative-suite (:additional-testset-fields options))
         additional-testset-fields (merge additional-testset-fields (:system-fields additional-testset-fields))]
+    (ensure-custom-field-values client [(:project-id options) (:display-action-logs options)] (:custom-fields additional-testset-fields))
     (api/ll-create-testset client
                        (:project-id options)
                        (merge {:name testset-name}

--- a/src/practitest_firecracker/eval.clj
+++ b/src/practitest_firecracker/eval.clj
@@ -93,16 +93,18 @@
                     step-defs
                     (read-string (:id test)))))
 
-(defn update-sf-testset [client {:keys [project-id display-action-logs] :as options} testset-name representative-suite testset-id]
-  (let [additional-testset-fields (eval-additional-fields representative-suite (:additional-testset-fields options))
+(defn update-sf-testset [client {:keys [project-id display-action-logs] :as options} testset-name sf-test-suite representative-suite testset-id]
+  (let [[test-def step-defs] (sf-test-suite->test-def options sf-test-suite)
+        additional-testset-fields (eval-additional-fields representative-suite (:additional-testset-fields options))
         additional-testset-fields (merge additional-testset-fields (:system-fields additional-testset-fields))]
     (ensure-custom-field-values client [project-id display-action-logs] (:custom-fields additional-testset-fields))
     (api/ll-update-testset client
                        [project-id display-action-logs]
-                       (merge {:name testset-name}
+                       (merge test-def
+                              {:name testset-name}
                               {:author-id (:author-id options)}
                               additional-testset-fields)
-                       []
+                       step-defs
                        testset-id)))
 
 (defn create-sf-testset [client options sf-test-suites testset-name representative-suite]

--- a/src/practitest_firecracker/parser/core.clj
+++ b/src/practitest_firecracker/parser/core.clj
@@ -421,13 +421,14 @@
     testsuite-list))
 
 (defn merged-testset [testsets tests testset-name]
-  (list {:tag       :testsuite
-         :test-list tests
-         :name      testset-name
-         :tests     (reduce + (map #(str-to-number %) (map :tests testsets)))
-         :time      (reduce + (map #(str-to-number %) (map :time testsets)))
-         :failures  (reduce + (map #(str-to-number %) (map :failues testsets)))
-         :skipped   (reduce + (map #(str-to-number %) (map :skipped testsets)))
+  (list {:tag         :testsuite
+         :test-list   tests
+         :name        testset-name
+         :suite-attrs (:attrs (first testsets))
+         :tests       (reduce + (map #(str-to-number %) (map :tests testsets)))
+         :time        (reduce + (map #(str-to-number %) (map :time testsets)))
+         :failures    (reduce + (map #(str-to-number %) (map :failues testsets)))
+         :skipped     (reduce + (map #(str-to-number %) (map :skipped testsets)))
          }))
 
 (defn merge-testsets [testsets testset-name]

--- a/src/practitest_firecracker/practitest.clj
+++ b/src/practitest_firecracker/practitest.clj
@@ -10,17 +10,18 @@
     [practitest-firecracker.eval :as eval]
     [clojure.pprint :as pprint]))
 
-(defn find-sf-testset [client [project-id display-action-logs] options testset-name]
+(defn find-sf-testset [client [project-id display-action-logs] options testset-name representative-suite]
   (let [testset (api/ll-find-testset client [project-id display-action-logs] testset-name)]
     (when testset
-      (eval/update-sf-testset client options testset-name testset (read-string (:id testset))))))
+      (eval/update-sf-testset client options testset-name representative-suite (read-string (:id testset))))))
 
 (defn create-testsets [client {:keys [project-id display-action-logs] :as options} xml]
   (doall
     (for [sf-test-suites xml]
       (let [testset-name (or (:name (:attrs sf-test-suites) (:name sf-test-suites)))
-            testset (or (find-sf-testset client [project-id display-action-logs] options testset-name)
-                        (eval/create-sf-testset client options (:test-cases sf-test-suites) testset-name))]
+            representative-suite (first (:test-list sf-test-suites))
+            testset (or (find-sf-testset client [project-id display-action-logs] options testset-name representative-suite)
+                        (eval/create-sf-testset client options (:test-cases sf-test-suites) testset-name representative-suite))]
         {(:id testset) (:test-list sf-test-suites)}))))
 
 (defn group-tests [testsets _ options]

--- a/src/practitest_firecracker/practitest.clj
+++ b/src/practitest_firecracker/practitest.clj
@@ -19,7 +19,7 @@
   (doall
     (for [sf-test-suites xml]
       (let [testset-name (or (:name (:attrs sf-test-suites) (:name sf-test-suites)))
-            representative-suite (first (:test-list sf-test-suites))
+            representative-suite (:suite-attrs sf-test-suites)
             testset (or (find-sf-testset client [project-id display-action-logs] options testset-name representative-suite)
                         (eval/create-sf-testset client options (:test-cases sf-test-suites) testset-name representative-suite))]
         {(:id testset) (:test-list sf-test-suites)}))))

--- a/src/practitest_firecracker/practitest.clj
+++ b/src/practitest_firecracker/practitest.clj
@@ -13,7 +13,7 @@
 (defn find-sf-testset [client [project-id display-action-logs] options testset-name representative-suite]
   (let [testset (api/ll-find-testset client [project-id display-action-logs] testset-name)]
     (when testset
-      (eval/update-sf-testset client options testset-name representative-suite (read-string (:id testset))))))
+      (eval/update-sf-testset client options testset-name testset representative-suite (read-string (:id testset))))))
 
 (defn create-testsets [client {:keys [project-id display-action-logs] :as options} xml]
   (doall

--- a/src/practitest_firecracker/query_dsl.cljc
+++ b/src/practitest_firecracker/query_dsl.cljc
@@ -110,20 +110,16 @@
                 :else                                 (str query))))))
 
 (defn read-query [s]
-  (let [query    (edn/read-string s)
-        compiler (fn compile-query [query]
-                   (if (list? query)
-                     (let [[op & args] query]
-                       {:op   (compile-query op)
-                        :args (vec (map compile-query args))})
-                     query))]
-    (if (not (or (number? query)
-                 (string? query)
-                 (double? query)
-                 (nil? query)))
-               (with-meta (compiler query)
-                          {:query true})
-               (compiler query))))
+  (if (and (string? s) (re-find #"^\s*[?(]" s))
+    (let [query    (edn/read-string s)
+          compiler (fn compile-query [query]
+                     (if (list? query)
+                       (let [[op & args] query]
+                         {:op   (compile-query op)
+                          :args (vec (map compile-query args))})
+                       query))]
+      (with-meta (compiler query) {:query true}))
+    s))
 
 (defn try-read-query [s]
   #?(:cljs

--- a/test/practitest_firecracker/eval_test.clj
+++ b/test/practitest_firecracker/eval_test.clj
@@ -9,7 +9,8 @@
   (parse-additional-fields
     (json/generate-string
       {:custom-fields {"---f-345678" "?hostname"
-                       "---f-66666"  "Salesforce"}})))
+                       "---f-66666"  "Salesforce"
+                       "---f-77777"  "Salesforce Inc"}})))
 
 (deftest create-sf-testset-resolves-dynamic-and-constant-fields
   (testing "create-sf-testset resolves query-DSL against the representative suite"
@@ -26,7 +27,9 @@
       (is (= "ci-runner-7" (get-in @captured [:custom-fields (keyword "---f-345678")]))
           "dynamic ?hostname must resolve to the suite value")
       (is (= "Salesforce" (get-in @captured [:custom-fields (keyword "---f-66666")]))
-          "constant value must pass through unchanged"))))
+          "constant value must pass through unchanged")
+      (is (= "Salesforce Inc" (get-in @captured [:custom-fields (keyword "---f-77777")]))
+          "multi-word constant value must not be truncated to its first word"))))
 
 (deftest update-sf-testset-resolves-dynamic-and-constant-fields
   (testing "update-sf-testset resolves query-DSL against the representative suite"
@@ -43,4 +46,6 @@
       (is (= "ci-runner-9" (get-in @captured [:custom-fields (keyword "---f-345678")]))
           "dynamic ?hostname must resolve to the suite value")
       (is (= "Salesforce" (get-in @captured [:custom-fields (keyword "---f-66666")]))
-          "constant value must pass through unchanged"))))
+          "constant value must pass through unchanged")
+      (is (= "Salesforce Inc" (get-in @captured [:custom-fields (keyword "---f-77777")]))
+          "multi-word constant value must not be truncated to its first word"))))

--- a/test/practitest_firecracker/eval_test.clj
+++ b/test/practitest_firecracker/eval_test.clj
@@ -1,0 +1,46 @@
+(ns practitest-firecracker.eval-test
+  (:require [clojure.test :refer :all]
+            [practitest-firecracker.eval :as eval]
+            [practitest-firecracker.api :as api]
+            [practitest-firecracker.cli :refer [parse-additional-fields]]
+            [cheshire.core :as json]))
+
+(def ^:private testset-fields
+  (parse-additional-fields
+    (json/generate-string
+      {:custom-fields {"---f-345678" "?hostname"
+                       "---f-66666"  "Salesforce"}})))
+
+(deftest create-sf-testset-resolves-dynamic-and-constant-fields
+  (testing "create-sf-testset resolves query-DSL against the representative suite"
+    (let [captured       (atom nil)
+          options        {:project-id                123
+                          :display-action-logs       false
+                          :additional-testset-fields testset-fields}
+          representative {:hostname "ci-runner-7"}]
+      (with-redefs [eval/ensure-custom-field-values (fn [& _] nil)
+                    api/ll-create-testset           (fn [_client _pid attributes _test-ids]
+                                                      (reset! captured attributes)
+                                                      {:id "999"})]
+        (eval/create-sf-testset nil options [] "My TestSet" representative))
+      (is (= "ci-runner-7" (get-in @captured [:custom-fields (keyword "---f-345678")]))
+          "dynamic ?hostname must resolve to the suite value")
+      (is (= "Salesforce" (get-in @captured [:custom-fields (keyword "---f-66666")]))
+          "constant value must pass through unchanged"))))
+
+(deftest update-sf-testset-resolves-dynamic-and-constant-fields
+  (testing "update-sf-testset resolves query-DSL against the representative suite"
+    (let [captured       (atom nil)
+          options        {:project-id                123
+                          :display-action-logs       false
+                          :additional-testset-fields testset-fields}
+          representative {:hostname "ci-runner-9"}]
+      (with-redefs [eval/ensure-custom-field-values (fn [& _] nil)
+                    api/ll-update-testset           (fn [_client _pdisplay attributes _steps _cf-id]
+                                                      (reset! captured attributes)
+                                                      {:id "999"})]
+        (eval/update-sf-testset nil options "My TestSet" representative 999))
+      (is (= "ci-runner-9" (get-in @captured [:custom-fields (keyword "---f-345678")]))
+          "dynamic ?hostname must resolve to the suite value")
+      (is (= "Salesforce" (get-in @captured [:custom-fields (keyword "---f-66666")]))
+          "constant value must pass through unchanged"))))

--- a/test/practitest_firecracker/eval_test.clj
+++ b/test/practitest_firecracker/eval_test.clj
@@ -39,7 +39,7 @@
                     api/ll-update-testset           (fn [_client _pdisplay attributes _steps _cf-id]
                                                       (reset! captured attributes)
                                                       {:id "999"})]
-        (eval/update-sf-testset nil options "My TestSet" representative 999))
+        (eval/update-sf-testset nil options "My TestSet" {} representative 999))
       (is (= "ci-runner-9" (get-in @captured [:custom-fields (keyword "---f-345678")]))
           "dynamic ?hostname must resolve to the suite value")
       (is (= "Salesforce" (get-in @captured [:custom-fields (keyword "---f-66666")]))

--- a/test/practitest_firecracker/practitest_test.clj
+++ b/test/practitest_firecracker/practitest_test.clj
@@ -1,6 +1,25 @@
 (ns practitest-firecracker.practitest-test
   (:require [clojure.test :refer :all]
-            [practitest-firecracker.practitest :refer :all]))
+            [practitest-firecracker.practitest :refer :all]
+            [practitest-firecracker.api :as api]
+            [practitest-firecracker.eval :as eval]))
+
+(deftest create-testsets-representative-suite-uses-suite-attrs
+  (testing "the representative suite passed downstream reflects the testsuite's own attrs, not a test-case's"
+    (let [captured       (atom nil)
+          sf-test-suites {:name        "MySuite"
+                           :suite-attrs {:name "MySuite" :hostname "ci-box-42"}
+                           :test-list   [{:name "testFoo" :classname "com.example.MyTest"}]}
+          options        {:project-id 123 :display-action-logs false}]
+      (with-redefs [api/ll-find-testset   (fn [& _] nil)
+                    eval/create-sf-testset (fn [_client _options _suites _name representative]
+                                              (reset! captured representative)
+                                              {:id "1"})]
+        (create-testsets nil options [sf-test-suites]))
+      (is (= "ci-box-42" (:hostname @captured))
+          "must resolve from the testsuite element's own attrs")
+      (is (not= "testFoo" (:name @captured))
+          "must not resolve from a test-case's attrs"))))
 
 (deftest test-translate-step-attributes
   (testing "test translate-step-attributes"


### PR DESCRIPTION
Fixes https://practitest-uri.atlassian.net/browse/PT1-7467

## Description
### What has been changed?
`additional-testset-fields` now supports **dynamic** query-DSL values (e.g. `?hostname`,
`?time`, or compound expressions), in addition to the constant values that already worked.
The values are resolved against the report's XML context, the same way `additional-test-fields`
and `additional-run-fields` already behave.

### Why is this needed?
Firecracker was documented (and shown in the help/JSON examples) as supporting XML-to-TestSet
field mapping, but it never actually evaluated the query DSL for TestSet fields. Only constant
values worked; a mapping like `{"---f-345678": "?hostname"}` was sent to the API literally as
`"?hostname"`. This blocked use cases such as auto-populating a TestSet "Version" custom field
from the execution context.

## Implementation Details

- **Root cause:** `cli.clj` already parsed `additional-testset-fields` strings into query-DSL
  ASTs symmetrically with test/run fields, but `eval.clj` never ran that AST through
  `eval-additional-fields` for TestSets. Constants happened to work; `?refs` and compound
  expressions did not.
- `eval/create-sf-testset` and `eval/update-sf-testset` now call `eval-additional-fields`
  against a **representative suite** (the first suite in the TestSet's `:test-list`), resolving
  `?hostname` to its value while leaving constants intact.
- The representative suite is passed as a **new, separate argument**, added alongside the
  existing inputs — `update-sf-testset` still receives the fetched TestSet entity and keeps its
  original `sf-test-suite->test-def` / `step-defs` flow unchanged. Field assignment is additive,
  not a replacement.
- `practitest/create-testsets` computes the representative suite and threads it through
  `find-sf-testset` and both the create/update paths.
- `create-sf-testset` now also calls `ensure-custom-field-values` (previously missing), so
  list-type custom fields (e.g. the "Version" list) are auto-extended when a resolved value is
  not yet a listed option — matching the behavior already present on the update path.
- No change to test-creation behavior.

### Automation:
- [x] Unit tests have been added/updated.
- [ ] No tests were added/updated. (Explain why)

Added `test/practitest_firecracker/eval_test.clj` covering both the create and update paths,
asserting a dynamic `?hostname` field resolves to the suite value and a constant field passes
through unchanged.

## Additional Notes
- **Behavioral note:** newly created TestSets now trigger `ensure-custom-field-values`, which may
  auto-extend list custom fields with new values (the same side effect already present on the
  update path). This is required for dynamic list-field values to be accepted by the API.
- The resolved value comes from the suite entity, which exposes raw XML attributes (`?hostname`,
  `?classname`, `?time`, ...) plus computed fields (`?package-name`, `?full-class-name`, ...).
  If a desired value (e.g. a version string) is not present as an XML attribute, it must be
  emitted into the report or derived via a DSL expression.
- Run tests with:
  `clojure -M -e "(require 'practitest-firecracker.eval-test)(clojure.test/run-tests
'practitest-firecracker.eval-test)"`